### PR TITLE
Use f32 for type stability

### DIFF
--- a/src/atomgraph.jl
+++ b/src/atomgraph.jl
@@ -89,8 +89,8 @@ lg.zero(AtomGraph) = AtomGraph(zero(SimpleWeightedGraph{Int32,Float32}), String[
 function normalized_laplacian(g::G) where G<:lg.AbstractGraph
     a = adjacency_matrix(g)
     d = vec(sum(a, dims=1))
-    inv_sqrt_d = diagm(0=>d.^(-0.5))
-    Float32.(I - inv_sqrt_d * a * inv_sqrt_d)
+    inv_sqrt_d = diagm(0=>d.^(-0.5f0))
+    I - inv_sqrt_d * a * inv_sqrt_d
 end
 
 normalized_laplacian(g::AtomGraph) = g.lapl


### PR DESCRIPTION
This doesn't mean much since we're not differentiating through this function (correct me if I'm wrong), but results in slightly clearer code, with type stability for the Float32 case which seems to be the default.

if we we're differentiating through this, we would also have seen a speedup in the backwards pass (`g isa AtomGraph` with a 7x10 graph) 

```julia
julia> @btime gradient(gr -> sum(normalized_laplacian(gr)), $(g.graph));
  82.412 μs (433 allocations: 17.92 KiB)

julia> @btime gradient(gr -> sum(normalized_laplacian2(gr)), $(g.graph));
  33.066 μs (108 allocations: 8.41 KiB)
```