### PR TITLE
Fix the overwrite option

### DIFF
--- a/src/pmg_graphs.jl
+++ b/src/pmg_graphs.jl
@@ -147,6 +147,7 @@ function build_graphs_batch(input_folder::String, featurization=AtomFeat[]; atom
     # check if input folder exists and contains things, if not throw error
     length(file_list)!=0 || throw(ArgumentError("No files in input directory!"))
 
+    local existing_files = []
     if(!overwrite && isdir(output_folder))
         existing_files = filter((file) -> isfile(file), readdir(output_folder, join = true))
         existing_files = map(file -> string(split(splitpath(file)[end], ".")[1]), existing_files)
@@ -176,7 +177,7 @@ function build_graphs_batch(input_folder::String, featurization=AtomFeat[]; atom
 
         id = split(splitpath(file)[end], ".")[1]
 
-        if (!overwrite) && isdir(output_folder) && (id in existing_files)
+        if (!overwrite) && (length(existing_files) != 0) && (id in existing_files)
             @info "Graph for $id already exists. Skipping, not overwriting."
             continue
         end

--- a/src/pmg_graphs.jl
+++ b/src/pmg_graphs.jl
@@ -140,7 +140,7 @@ Other optional keyword arguments are the optional arguments to `build_graph`: `u
 
 See also: [`build_graph`](@ref)
 """
-function build_graphs_batch(input_folder::String, featurization=AtomFeat[]; atom_featurevecs=Dict{String, Vector{Float32}}(), use_voronoi=false, radius=8.0, max_num_nbr=12, dist_decay_func=inverse_square, normalize=true, output_folder="", overwrite=true)
+function build_graphs_batch(input_folder::String, featurization=AtomFeat[]; atom_featurevecs=Dict{String, Vector{Float32}}(), use_voronoi=false, radius=8.0, max_num_nbr=12, dist_decay_func=inverse_square, normalize=true, output_folder="", overwrite=false)
 
     file_list = filter((file) -> isfile(file), readdir(input_folder, join = true))
 

--- a/test/atomgraph_tests.jl
+++ b/test/atomgraph_tests.jl
@@ -58,7 +58,7 @@ using ChemistryFeaturization
     
     # and test this one for the other signatures too
     add_features_batch!(ags, vecs, featurization)
-    @test ags[1].features[:,1]==Float32.([0;1;0;0;0;1;0])==ags[2].features[:,1]    
+    @test ags[1].features[:,1]==Float32.([0;1;0;0;0;1;0])==ags[2].features[:,1]
     # sneakily test that block will always be length 4, i.e. second entry ignored
     add_features_batch!(ags, Symbol.(["X", "Block"]); nbins=[3,3])
     @test ags[1].features[:,2]==Float32.([0;1;0;0;1;0;0])==ags[2].features[:,2]
@@ -117,8 +117,9 @@ end
     input_folder = joinpath(@__DIR__, "test_data")
     output_folder=joinpath(@__DIR__, "test_data", "graphs")
 
-    gs = build_graphs_batch(input_folder, featurization, output_folder=output_folder)
-    gs2 = build_graphs_batch(input_folder, feature_names)
+    # sneakily run the case wherein output_folder doesn't exist, and overwrite is set to false
+    gs = build_graphs_batch(input_folder, featurization, output_folder = output_folder)
+    gs2 = build_graphs_batch(input_folder, feature_names, overwrite = true)
     @test repr.(gs)==repr.(gs2) # sneakily testing pretty printing also...
 
     # test reading from individual files


### PR DESCRIPTION
* Set the default option of `overwrite` to `false` instead of `true`.
* `overwrite=false` used in conjunction with an `output_folder` that doesn't exist gives an error. Fix that.