### PR TITLE
src: pmg_graphs: fix return value issue, and add new test

### DIFF
--- a/src/pmg_graphs.jl
+++ b/src/pmg_graphs.jl
@@ -178,6 +178,7 @@ function build_graphs_batch(input_folder::String, featurization=AtomFeat[]; atom
         id = split(splitpath(file)[end], ".")[1]
 
         if (!overwrite) && (length(existing_files) != 0) && (id in existing_files)
+            push!(graphs, deserialize(joinpath(output_folder, string(id, ".jls"))))
             @info "Graph for $id already exists. Skipping, not overwriting."
             continue
         end
@@ -189,14 +190,17 @@ function build_graphs_batch(input_folder::String, featurization=AtomFeat[]; atom
             @warn "Unable to build graph for $file"
             continue
         end
+
         ag.id = id
         if to_featurize
             add_features!(ag, atom_featurevecs, featurization)
         end
+
         if to_serialize
             graph_path = joinpath(output_folder, string(id, ".jls"))
             serialize(graph_path, ag)
         end
+
         push!(graphs, ag)
     end
     return graphs

--- a/test/atomgraph_tests.jl
+++ b/test/atomgraph_tests.jl
@@ -122,6 +122,12 @@ end
     gs2 = build_graphs_batch(input_folder, feature_names, overwrite = true)
     @test repr.(gs)==repr.(gs2) # sneakily testing pretty printing also...
 
+    rm(output_folder; recursive=true)
+
+    gs = build_graphs_batch(input_folder, featurization, output_folder = output_folder)
+    gs2 = build_graphs_batch(input_folder, feature_names, output_folder = output_folder, overwrite = false)
+    @test repr.(gs)==repr.(gs2) # sneakily testing pretty printing also...
+
     # test reading from individual files
     g1 = deserialize(joinpath(@__DIR__, "test_data","graphs","mp-195.jls"))
     @test size(g1)==(4,4)


### PR DESCRIPTION
Consider the case, where build_graphs_batches() is called and there
already exists an output_folder, and overwrite = false.

In this case, the build_graph() function isn't called (as expected), but
the existing graphs aren't returned to the caller; which is not the
expected behaviour.

Also, add a test which checks for this condition.

Signed-off-by: Anant Thazhemadam <anant.thazhemadam@gmail.com>