### PR TITLE
refactoring: rename fields and use more explicit variable names

### DIFF
--- a/src/ChemistryFeaturization.jl
+++ b/src/ChemistryFeaturization.jl
@@ -77,7 +77,7 @@ function decode(f::AbstractFeature, encoded_feature)
 end
 
 #= FEATURIZATION OBJECTS
-All such objects should define at least one list of <:AbstractFeature objects and either work according to the generic featurize! defined herein or dispatch featurize! if customized behavior is needed.
+All such objects should define at least one list of <: AbstractFeature objects and either work according to the generic featurize! defined herein or dispatch featurize! if customized behavior is needed.
 =#
 
 # export...

--- a/src/atoms/atomgraph.jl
+++ b/src/atoms/atomgraph.jl
@@ -15,7 +15,7 @@ A type representing an atomic structure as a graph (`gr`).
   [`build_graph`](@ref) for more on generating the weights.
 - `elements::Vector{String}`: list of elemental symbols corresponding to each node of the
   graph
-- `lapl::Matrix{Float32}`: Normalized graph Laplacian matrix, stored to speed up
+- `laplacian::Matrix{Float32}`: Normalized graph Laplacian matrix, stored to speed up
   convolution operations by avoiding recomputing it every pass.
 - `features::Matrix{Float32}`: Feature matrix of size (# features, # nodes). AtomGraph can
   be initialized without defining this field, but if it is defined, the subsequent field must be also.
@@ -25,84 +25,88 @@ A type representing an atomic structure as a graph (`gr`).
   dataset.
 """
 mutable struct AtomGraph <: AbstractAtoms
-    graph::SimpleWeightedGraph{<:Integer,<:Real}
+    graph::SimpleWeightedGraph{<: Integer, <: Real}
     elements::Vector{String}
-    lapl::Matrix{<:Real} # wanted to use LightGraphs.LinAlg.NormalizedGraphLaplacian but seems this doesn't support weighted graphs?
-    atom_feats::Union{Matrix{<:Real},Nothing} # if we add edge features this type will have to relax
+    laplacian::Matrix{<: Real} # wanted to use LightGraphs.LinAlg.NormalizedGraphLaplacian but seems this doesn't support weighted graphs?
+    atom_features::Union{Matrix{<: Real},Nothing} # if we add edge features this type will have to relax
     featurization::Union{AbstractFeaturization,Nothing}
     id::String # or maybe we let it be a number too?
 end
 
+
 # first, the basic constructor
 """
-    AtomGraph(gr, el_list, features, featurization, id="")
-    AtomGraph(gr, el_list, id="")
-    AtomGraph(adj, el_list, features, featurization, id="")
-    AtomGraph(adj, el_list, id="")
+    AtomGraph(gr, elements, features, featurization, id="")
+    AtomGraph(gr, elements, id="")
+    AtomGraph(adj, elements, features, featurization, id="")
+    AtomGraph(adj, elements, id="")
 
 Construct an AtomGraph object, either directly from a SimpleWeightedGraph `gr` or from an
-adjacency matrix `adj`, along with, at minimum, the list of elemental symbols `el_list`
+adjacency matrix `adj`, along with, at minimum, the list of elemental symbols `elements`
 representing each node. Note that the object can be initialized without features, but if
 features are provided, so too must be the featurization scheme, in order to maintain
 "decodability" of features.
 """
 function AtomGraph(
-    gr::SimpleWeightedGraph{A,B},
-    el_list::Vector{String},
-    features::Matrix{<:Real},
+    gr::SimpleWeightedGraph{A, B},
+    elements::Vector{String},
+    features::Matrix{<: Real},
     featurization::AbstractFeaturization,
     id = "",
-) where {B<:Real,A<:Integer}
-    # check that el_list is the right length
+) where {B <: Real, A <: Integer}
+    # check that elements is the right length
     num_atoms = size(gr)[1]
-    @assert length(el_list) == num_atoms "Element list length doesn't match graph size!"
+    @assert length(elements) == num_atoms "Element list length doesn't match graph size!"
 
     # check that features is the right dimensions (# features x # nodes)
     expected_feature_length = sum(f.num_bins for f in featurization)
     @assert size(features) == (expected_feature_length, num_atoms) "Feature matrix is of wrong dimension! It should be of size (# features, # nodes)"
 
     # if all these are good, calculate laplacian and build the thing
-    lapl = normalized_laplacian(gr)
-    AtomGraph(gr, el_list, lapl, features, featurization, id)
+    laplacian = normalized_laplacian(gr)
+    AtomGraph(gr, elements, laplacian, features, featurization, id)
 end
+
 
 # one without features or featurization initialized yet
 function AtomGraph(
-    gr::SimpleWeightedGraph{A,B},
-    el_list::Vector{String},
+    gr::SimpleWeightedGraph{A, B},
+    elements::Vector{String},
     id = ""
-) where {B<:Real,A<:Integer}
-    # check that el_list is the right length
+) where {B <: Real,A <: Integer}
+    # check that elements is the right length
     num_atoms = size(gr)[1]
-    @assert length(el_list) == num_atoms "Element list length doesn't match graph size!"
+    @assert length(elements) == num_atoms "Element list length doesn't match graph size!"
 
-    lapl = B.(normalized_laplacian(gr))
-    AtomGraph(gr, el_list, lapl, nothing, nothing, id)
+    laplacian = B.(normalized_laplacian(gr))
+    AtomGraph(gr, elements, laplacian, nothing, nothing, id)
 end
 
 
 # initialize directly from adjacency matrix
 AtomGraph(
     adj::Array{R},
-    el_list::Vector{String},
+    elements::Vector{String},
     features::Matrix{R},
     featurization::AbstractFeaturization,
     id = ""
-) where {R<:Real} =
-    AtomGraph(SimpleWeightedGraph{R}(adj), el_list, features, featurization, id)
+) where {R <: Real} =
+    AtomGraph(SimpleWeightedGraph{R}(adj), elements, features, featurization, id)
 
-AtomGraph(adj::Array{R}, el_list::Vector{String}, id = "") where {R<:Real} =
-    AtomGraph(SimpleWeightedGraph{R}(adj), el_list, id)
+
+AtomGraph(adj::Array{R}, elements::Vector{String}, id = "") where {R <: Real} =
+    AtomGraph(SimpleWeightedGraph{R}(adj), elements, id)
 
 
 # pretty printing, short version
 function Base.show(io::IO, ag::AtomGraph)
     st = "AtomGraph $(ag.id) with $(nv(ag.graph)) nodes, $(ne(ag.graph)) edges"
     if !isnothing(ag.featurization)
-        st = string(st, ", feature vector length $(size(ag.atom_feats)[1])")
+        st = string(st, ", feature vector length $(size(ag.atom_features)[1])")
     end
     print(io, st)
 end
+
 
 # pretty printing, long version
 function Base.show(io::IO, ::MIME"text/plain", ag::AtomGraph)
@@ -112,7 +116,7 @@ function Base.show(io::IO, ::MIME"text/plain", ag::AtomGraph)
     else
         st = string(
                     st,
-                    "$(size(ag.atom_feats)[1])\n   encoded features: ",
+                    "$(size(ag.atom_features)[1])\n   encoded features: ",
                     ag.featurization,
                 )
     end
@@ -130,21 +134,21 @@ Compute the normalized graph Laplacian matrix of the input graph, defined as
 
 where ``A`` is the adjacency matrix and ``D`` is the degree matrix.
 """
-function normalized_laplacian(g::G) where {G<:LightGraphs.AbstractGraph}
+function normalized_laplacian(g::G) where {G <: LightGraphs.AbstractGraph}
     a = adjacency_matrix(g)
     d = vec(sum(a, dims = 1))
     inv_sqrt_d = diagm(0 => d .^ (-0.5f0))
-    lapl = Float32.(I - inv_sqrt_d * a * inv_sqrt_d)
-    !any(isnan, lapl) || throw(
+    laplacian = Float32.(I - inv_sqrt_d * a * inv_sqrt_d)
+    !any(isnan, laplacian) || throw(
         ArgumentError(
             "NaN values in graph Laplacian! This is most likely due to atomic separations larger than the specified cutoff distance leading to block zeros in the adjacency matrix...try increasing the cutoff distance or inspecting your structure to ensure the file is correct.",
         ),
     )
-    return lapl
+    return laplacian
 end
 
 
-normalized_laplacian(ag::AtomGraph) = ag.lapl
+normalized_laplacian(ag::AtomGraph) = ag.laplacian
 
 
 # now visualization stuff...
@@ -161,8 +165,8 @@ end
 
 # helper fcn for sorting because edge ordering isn't preserved when converting to SimpleGraph
 function lt_edge(
-    e1::SimpleWeightedGraphs.SimpleWeightedEdge{<:Integer,<:Real},
-    e2::SimpleWeightedGraphs.SimpleWeightedEdge{<:Integer,<:Real},
+    e1::SimpleWeightedGraphs.SimpleWeightedEdge{<: Integer, <: Real},
+    e2::SimpleWeightedGraphs.SimpleWeightedEdge{<: Integer, <: Real},
 )
     if e1.src < e2.src
         return true
@@ -183,6 +187,7 @@ function graph_edgewidths(ag::AtomGraph)
     end
     return edgewidths
 end
+
 
 "Visualize a given graph."
 function visualize(ag::AtomGraph)

--- a/src/atoms/weavemol.jl
+++ b/src/atoms/weavemol.jl
@@ -4,8 +4,8 @@
 mutable struct WeaveMol <: AbstractAtoms
     smiles::String
     elements::Vector{String}
-    atom_feats::Vector{SomethingOrOther} # I need to look more carefully to figure this out, heh
-    pair_feats::Vector{SomethingOrOther}
+    atom_features::Vector{SomethingOrOther} # I need to look more carefully to figure this out, heh
+    pair_features::Vector{SomethingOrOther}
     featurization::WeaveFeaturization
     id::Any # probably makes sense to have this in addition to smiles? Maybe?
 end

--- a/src/featurizations/graphnodefeaturization.jl
+++ b/src/featurizations/graphnodefeaturization.jl
@@ -3,7 +3,7 @@
 Featurization for `AtomGraph` objects that featurizes graph nodes only.
 =#
 struct GraphNodeFeaturization <: AbstractFeaturization
-    atom_feats::Vector{AtomFeature}
+    atom_features::Vector{AtomFeature}
 end
 
 # TODO: pretty printing

--- a/test/AtomGraph/atomgraph.jl
+++ b/test/AtomGraph/atomgraph.jl
@@ -74,7 +74,7 @@ end
     serialize(abspath(@__DIR__, "../test_data", "testgraph.jls"), ag)
     ag2 = deserialize(abspath(@__DIR__, "../test_data", "testgraph.jls"))
     @test ag2.elements==ag.elements
-    @test ag.lapl==ag2.lapl
+    @test ag.laplacian==ag2.laplacian
     @test ag.features==ag2.features
     for i in 1:2
         for field in [:name, :categorical, :num_bins, :logspaced, :vals]


### PR DESCRIPTION
* f9c11e7 renamed `atom_feats` and `pair_feats` in `WeaveFeaturization`
to `atom_features` and `pair_features`. Rename other instances of these
fields everywhere else too accordingly to maintain consistency.
* Rename `lapl` to `laplacian` to be a little more explicit.
* Add spaces around "`<:`" so things seem more spaced out, and less
congested.

Signed-off-by: Anant Thazhemadam <anant.thazhemadam@gmail.com>